### PR TITLE
AFURLRequestSerialization: Remove headers added by default to requests.

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -206,11 +206,6 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
 
     [self setValue:[AFHTTPRequestSerializer acceptLanguagesHeader] forHTTPHeaderField:@"Accept-Language"];
 
-    NSString * _Nullable userAgent = [AFHTTPRequestSerializer userAgentHeader];
-    if (userAgent) {
-        [self setValue:userAgent forHTTPHeaderField:@"User-Agent"];
-    }
-
     // HTTP Method Definitions; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html
     self.HTTPMethodsEncodingParametersInURI = [NSSet setWithObjects:@"GET", @"HEAD", @"DELETE", nil];
 
@@ -240,37 +235,6 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
     });
 
     return acceptLanguagesHeader;
-}
-
-// User-Agent Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43
-+ (nullable NSString *)userAgentHeader {
-    static NSString * _Nullable userAgentHeader;
-
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        #if TARGET_OS_IOS
-            NSString *userAgent = [NSString stringWithFormat:@"%@/%@ (%@; iOS %@; Scale/%0.2f)", [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleExecutableKey] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleIdentifierKey], [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleVersionKey], [[UIDevice currentDevice] model], [[UIDevice currentDevice] systemVersion], [[UIScreen mainScreen] scale]];
-        #elif TARGET_OS_WATCH
-            NSString *userAgent = [NSString stringWithFormat:@"%@/%@ (%@; watchOS %@; Scale/%0.2f)", [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleExecutableKey] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleIdentifierKey], [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleVersionKey], [[WKInterfaceDevice currentDevice] model], [[WKInterfaceDevice currentDevice] systemVersion], [[WKInterfaceDevice currentDevice] screenScale]];
-        #elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
-            NSString *userAgent = [NSString stringWithFormat:@"%@/%@ (Mac OS X %@)", [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleExecutableKey] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleIdentifierKey], [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"] ?: [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleVersionKey], [[NSProcessInfo processInfo] operatingSystemVersionString]];
-        #endif
-
-            if (!userAgent) {
-                return;
-            }
-        
-            userAgentHeader = userAgent;
-
-            if (![userAgent canBeConvertedToEncoding:NSASCIIStringEncoding]) {
-                NSMutableString *mutableUserAgent = [userAgent mutableCopy];
-                if (CFStringTransform((__bridge CFMutableStringRef)(mutableUserAgent), NULL, (__bridge CFStringRef)@"Any-Latin; Latin-ASCII; [:^ASCII:] Remove", false)) {
-                    userAgentHeader = mutableUserAgent;
-                }
-            }
-    });
-
-    return userAgentHeader;
 }
 
 - (void)dealloc {


### PR DESCRIPTION
We found out that when the app's version changes, cached responses that
are still in the cache are ignored when doing a networking request.
After investigating further the problem stems from Apple's network
library, `CFNetwork`, that compares the user agent HTTP header with the
one of the cached request. If they don't match, a network request is
invoked instead of taking the cached response.

The solution is simply to remove the headers that AFNetworking adds by
default.

Furthermore, `CFNetwork` itself sends this header and accept-languages
header, and this time they don't interfere with the cache.

Before this change:

User-Agent: MyApp/1.5.6 (iPhone; iOS 13.3.1; Scale/2.00)

After this change:

User-Agent: MyApp/1.5.6 CFNetwork/1121.2.2 Darwin/19.3.0