### PR TITLE
project: support application extensions.

### DIFF
--- a/AFNetworking.xcodeproj/project.pbxproj
+++ b/AFNetworking.xcodeproj/project.pbxproj
@@ -1401,6 +1401,7 @@
 		299522421BBF104D00859F49 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				BITCODE_GENERATION_MODE = marker;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
@@ -1422,6 +1423,7 @@
 		299522431BBF104D00859F49 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				BITCODE_GENERATION_MODE = bitcode;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
Without the given flag, this raises a warning for
`VenusNotificationService` that we are linking against a dylib which is
not safe for use in application extensions.
This warning occurred because `AFNetworking` was added as a dependency
to Intelligence (https://github.com/Lightricks/Foundations/pull/5850),
which VenusNotificationService uses.

Discussed this with The Eshed and he told me that it is safe to allow
this for app extensions.

Verified that after enabling this flag, the warning disappears.

@ashdnazg @barakwei