### PR TITLE
AFSecurityPolicy: avoid using deprecated method.

### DIFF
--- a/AFNetworking/AFSecurityPolicy.m
+++ b/AFNetworking/AFSecurityPolicy.m
@@ -51,30 +51,12 @@ static BOOL AFSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
 static id AFPublicKeyForCertificate(NSData *certificate) {
     id allowedPublicKey = nil;
     SecCertificateRef allowedCertificate;
-    SecPolicyRef policy = nil;
-    SecTrustRef allowedTrust = nil;
-    SecTrustResultType result;
 
     allowedCertificate = SecCertificateCreateWithData(NULL, (__bridge CFDataRef)certificate);
     __Require_Quiet(allowedCertificate != NULL, _out);
 
-    policy = SecPolicyCreateBasicX509();
-    __Require_noErr_Quiet(SecTrustCreateWithCertificates(allowedCertificate, policy, &allowedTrust), _out);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    __Require_noErr_Quiet(SecTrustEvaluate(allowedTrust, &result), _out);
-#pragma clang diagnostic pop
-    allowedPublicKey = (__bridge_transfer id)SecTrustCopyPublicKey(allowedTrust);
-
+    allowedPublicKey = (__bridge_transfer id)SecCertificateCopyKey(allowedCertificate);
 _out:
-    if (allowedTrust) {
-        CFRelease(allowedTrust);
-    }
-
-    if (policy) {
-        CFRelease(policy);
-    }
-
     if (allowedCertificate) {
         CFRelease(allowedCertificate);
     }


### PR DESCRIPTION
The method `AFPublicKeyForCertificate` which just extracts the public
key from a certificate used the method `SecTrustEvaluate` to do it.
That method is deprecated and considered "heavy" - every time it's
called from the main thread we get a runtime warning to not do this
and we do this a lot.

This commit makes the method extract the public key in a much simpler
way, using a dedicated method. SSL pinning was tested and seems to be
in working order after this change, and the runtime errors are gone.
