### PR TITLE
AFURLRequestSerialization: Update header dispatch queues.

### DIFF
--- a/AFNetworking/AFURLRequestSerialization.m
+++ b/AFNetworking/AFURLRequestSerialization.m
@@ -299,7 +299,7 @@ static void *AFHTTPRequestSerializerObserverContext = &AFHTTPRequestSerializerOb
 - (void)setValue:(NSString *)value
 forHTTPHeaderField:(NSString *)field
 {
-    dispatch_barrier_async(self.requestHeaderModificationQueue, ^{
+    dispatch_barrier_sync(self.requestHeaderModificationQueue, ^{
         [self.mutableHTTPRequestHeaders setValue:value forKey:field];
     });
 }
@@ -321,7 +321,7 @@ forHTTPHeaderField:(NSString *)field
 }
 
 - (void)clearAuthorizationHeader {
-    dispatch_barrier_async(self.requestHeaderModificationQueue, ^{
+    dispatch_barrier_sync(self.requestHeaderModificationQueue, ^{
         [self.mutableHTTPRequestHeaders removeObjectForKey:@"Authorization"];
     });
 }


### PR DESCRIPTION
This PR addresses a notable concurrency issue observed in AFURLRequestSerialization, which is causing unexpected crashes and UI malfunctions on Photoleap. The root cause of this issue is traced back to concurrent triggering of AFURLRequestSerialization requests that subsequently lead to race conditions, where background threads are blocked.

We discovered this when we observed that continuations were being triggered twice, leading to unanticipated crashes. The problem seems to amplify with an increase in the concurrent requests, making it easily replicable. This anomaly is manifesting itself in a variety of ways, including the inability to load images, and blocking the activation of our async flows. Interestingly, while the main thread remains functional, most button actions turn unresponsive as a lot use Task { } to trigger a flow which puts work onto a background thread.

After inspection, we found that this issue can be resolved by replacing dispatch_barrier_async with dispatch_barrier_sync for the header request updates. This modification aligns our fork with an upstream change that has already been implemented, as seen [here](https://github.com/AFNetworking/AFNetworking/pull/4474/files).

Apart from this, we have conducted a comprehensive comparison between our fork and the upstream, to identify and understand the disparities. [This](https://github.com/AFNetworking/AFNetworking/commit/f9b42b504908f47b443db9c74d30f0a070ced710) is a significant change but it passes a test I wrote on Fiber and all the other deviations are related to warnings so have been retained.